### PR TITLE
Unify LLM client creation and gauntlet defaults

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,11 +5,13 @@ on:
     branches: [ main ]
     paths:
       - 'docs/**'
+      - 'OAUTH_SUPPORT.md'
       - '.github/workflows/pages.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'docs/**'
+      - 'OAUTH_SUPPORT.md'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
     inputs:

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ jail/*.js.map
 .secrets
 # Secrets
 .env
+GoogleOAuthCredentails*.json
+jail/codex-tmp/

--- a/OAUTH_SUPPORT.md
+++ b/OAUTH_SUPPORT.md
@@ -1,0 +1,82 @@
+# OAuth Support
+
+This document describes how Morpheum uses OAuth to authenticate LLM providers without API keys, starting with Gemini via a Google account. It also outlines the common OAuth design so OpenAI OAuth can be added later with minimal changes.
+
+## Summary
+
+- OAuth is supported through a loopback (localhost redirect) flow.
+- Tokens are stored locally on the host machine and refreshed automatically.
+- Gemini OAuth uses Google accounts (including Gmail accounts) with the Generative Language API enabled.
+
+## Supported Providers
+
+- Gemini (Google Generative Language API) via OAuth loopback flow.
+- OpenAI OAuth is planned; the same token storage and refresh plumbing is reused.
+
+## Gemini OAuth Setup
+
+### 1) Create OAuth credentials
+
+1. Create or select a Google Cloud project.
+2. Enable the **Generative Language API** in the project.
+3. Configure the OAuth consent screen.
+4. Create an OAuth client of type **Desktop app** with redirect URI `http://127.0.0.1`.
+5. Copy the Client ID and Client Secret.
+
+### 2) Set environment variables
+
+Set these on the host running the bot:
+
+- `GOOGLE_OAUTH_CLIENT_ID` (required)
+- `GOOGLE_OAUTH_CLIENT_SECRET` (recommended)
+- `GOOGLE_OAUTH_SCOPES` (optional; space-separated list, defaults to `https://www.googleapis.com/auth/generative-language`)
+- `GEMINI_MODEL` (optional; default is `gemini-3-pro-preview`)
+- `GEMINI_BASE_URL` (optional; default is `https://generativelanguage.googleapis.com/v1beta`)
+
+### 3) Start the OAuth loopback flow
+
+In Matrix, run:
+
+- `!llm oauth gemini start`
+
+The bot returns an authorization URL using a loopback IP redirect (`http://127.0.0.1`). Open it, sign in with the Google account, and approve access. The loopback handler will capture the authorization code automatically.
+
+### 4) Switch to Gemini
+
+- `!llm switch gemini [model] [baseUrl]`
+
+Example:
+
+- `!llm switch gemini gemini-1.5-pro`
+
+## OAuth Commands
+
+- `!llm oauth gemini start` - Begin OAuth loopback flow and wait for authorization
+- `!llm oauth gemini status` - Show whether a refresh token is stored and if the access token is valid
+- `!llm oauth gemini revoke` - Delete stored tokens for the provider
+
+## Token Storage
+
+OAuth tokens are stored on the host at:
+
+- `~/.config/morpheum/oauth.json`
+
+This file contains refresh tokens and (if present) short-lived access tokens. Do not commit this file. Access tokens are refreshed automatically when expired.
+
+## Scopes
+
+Gemini OAuth uses the following scope by default for loopback flow:
+
+- `https://www.googleapis.com/auth/generative-language`
+
+If you are using a different Gemini backend, you may need a different scope and base URL.
+
+## OpenAI OAuth (Planned)
+
+The OAuth implementation is provider-agnostic. To add OpenAI OAuth later, the following will be needed:
+
+- OpenAI OAuth client credentials
+- OpenAI OAuth authorization endpoints and scopes
+- Wiring the provider config into the existing OAuth manager
+
+No API behavior changes are required beyond passing the bearer token into the OpenAI client.

--- a/docs/_devlogs/2025-09-15-fix-github-pages-jekyll-build-failures.md
+++ b/docs/_devlogs/2025-09-15-fix-github-pages-jekyll-build-failures.md
@@ -44,7 +44,7 @@ title: "Project Renaming (Morpheus to Morpheum)"
 
 ```liquid
 <!-- BEFORE: Invalid include path -->
-{% include_relative ../../ONBOARDING.md %}
+{% raw %}{% include_relative ../../ONBOARDING.md %}{% endraw %}
 
 <!-- AFTER: Valid include path -->
 {% include ONBOARDING.md %}

--- a/docs/_devlogs/2026-01-21-add-gemini-oauth-support.md
+++ b/docs/_devlogs/2026-01-21-add-gemini-oauth-support.md
@@ -1,0 +1,22 @@
+---
+title: "Add Gemini OAuth Support"
+date: 2026-01-21
+author: "Codex"
+tags: ["development", "oauth", "gemini", "llm"]
+---
+
+## Actions Taken
+- Implemented OAuth loopback (PKCE) flow and token storage for Gemini access without API keys.
+- Wired OAuth-backed credentials into the shared LLM client factory and updated bot commands to initiate, check, and revoke OAuth sessions.
+- Documented OAuth setup, scopes, and default model usage in `OAUTH_SUPPORT.md` and docs site.
+- Added helper tooling to append Google OAuth client environment variables into `.secrets`.
+
+## Friction/Success Points
+- Google OAuth device flow rejected the Generative Language scopes; loopback was required to complete authorization.
+- Misconfigured or stale environment variables (client IDs/scopes) led to repeated `invalid_request` and `invalid_scope` errors until refreshed.
+- The Jekyll site required moving root docs into `docs/_includes/` rather than using `include_relative` outside the docs tree.
+
+## Technical Learnings
+- Gemini OAuth requires the Desktop app client type and a loopback redirect on `127.0.0.1` with PKCE; device flow is not supported for these scopes.
+- The scope value must match the Generative Language API capabilities; mismatched scopes yield `invalid_scope` even when the API is enabled.
+- Centralizing OAuth in the LLM client factory avoids diverging auth behavior between bot commands and gauntlet runs.

--- a/docs/_devlogs/2026-01-21-fix-pages-workflow-oauth-docs.md
+++ b/docs/_devlogs/2026-01-21-fix-pages-workflow-oauth-docs.md
@@ -1,0 +1,17 @@
+---
+title: "Fix Pages Workflow Trigger for OAuth Docs"
+date: 2026-01-21
+author: "Codex"
+tags: ["documentation", "github-pages", "workflow"]
+---
+
+## Actions Taken
+- Updated the GitHub Pages workflow to rebuild when `OAUTH_SUPPORT.md` changes.
+- Added a Jekyll documentation page that includes the root OAuth support doc via `include_relative`.
+- Linked the new OAuth support page from the documentation index.
+
+## Friction/Success Points
+- Ensured the workflow triggers for root documentation updates to keep GitHub Pages current.
+
+## Technical Learnings
+- Root-level docs referenced from Jekyll need workflow path triggers to ensure deploys run when only root files change.

--- a/docs/_devlogs/2026-01-21-unify-llm-client-factory.md
+++ b/docs/_devlogs/2026-01-21-unify-llm-client-factory.md
@@ -1,0 +1,20 @@
+---
+title: "Unify LLM Client Creation and Gauntlet Defaults"
+date: 2026-01-21
+author: "Codex"
+tags: ["development", "llm", "gauntlet", "oauth"]
+---
+
+## Actions Taken
+- Consolidated LLM client creation to a single async factory with lazy initialization in the bot.
+- Added OAuth-aware Gemini client handling in the shared factory and updated gauntlet flows to await async metrics and configuration.
+- Updated gauntlet help text and defaults to use provider-configured models when none are supplied.
+- Documented OAuth loopback configuration and default Gemini model in `OAUTH_SUPPORT.md`.
+
+## Friction/Success Points
+- Pre-commit hooks required devlog and task entries, which helped keep changes traceable.
+- Untracked local artifacts required explicit ignore rules to keep the PR clean.
+
+## Technical Learnings
+- Centralizing LLM client creation avoids drift between direct instantiation and factory-based creation, especially for OAuth-backed providers.
+- Async factories integrate cleanly with lazy initialization patterns, enabling dynamic provider switching without duplicate construction logic.

--- a/docs/_includes/OAUTH_SUPPORT.md
+++ b/docs/_includes/OAUTH_SUPPORT.md
@@ -1,0 +1,82 @@
+# OAuth Support
+
+This document describes how Morpheum uses OAuth to authenticate LLM providers without API keys, starting with Gemini via a Google account. It also outlines the common OAuth design so OpenAI OAuth can be added later with minimal changes.
+
+## Summary
+
+- OAuth is supported through a loopback (localhost redirect) flow.
+- Tokens are stored locally on the host machine and refreshed automatically.
+- Gemini OAuth uses Google accounts (including Gmail accounts) with the Generative Language API enabled.
+
+## Supported Providers
+
+- Gemini (Google Generative Language API) via OAuth loopback flow.
+- OpenAI OAuth is planned; the same token storage and refresh plumbing is reused.
+
+## Gemini OAuth Setup
+
+### 1) Create OAuth credentials
+
+1. Create or select a Google Cloud project.
+2. Enable the **Generative Language API** in the project.
+3. Configure the OAuth consent screen.
+4. Create an OAuth client of type **Desktop app** with redirect URI `http://127.0.0.1`.
+5. Copy the Client ID and Client Secret.
+
+### 2) Set environment variables
+
+Set these on the host running the bot:
+
+- `GOOGLE_OAUTH_CLIENT_ID` (required)
+- `GOOGLE_OAUTH_CLIENT_SECRET` (recommended)
+- `GOOGLE_OAUTH_SCOPES` (optional; space-separated list, defaults to `https://www.googleapis.com/auth/generative-language`)
+- `GEMINI_MODEL` (optional; default is `gemini-3-pro-preview`)
+- `GEMINI_BASE_URL` (optional; default is `https://generativelanguage.googleapis.com/v1beta`)
+
+### 3) Start the OAuth loopback flow
+
+In Matrix, run:
+
+- `!llm oauth gemini start`
+
+The bot returns an authorization URL using a loopback IP redirect (`http://127.0.0.1`). Open it, sign in with the Google account, and approve access. The loopback handler will capture the authorization code automatically.
+
+### 4) Switch to Gemini
+
+- `!llm switch gemini [model] [baseUrl]`
+
+Example:
+
+- `!llm switch gemini gemini-1.5-pro`
+
+## OAuth Commands
+
+- `!llm oauth gemini start` - Begin OAuth loopback flow and wait for authorization
+- `!llm oauth gemini status` - Show whether a refresh token is stored and if the access token is valid
+- `!llm oauth gemini revoke` - Delete stored tokens for the provider
+
+## Token Storage
+
+OAuth tokens are stored on the host at:
+
+- `~/.config/morpheum/oauth.json`
+
+This file contains refresh tokens and (if present) short-lived access tokens. Do not commit this file. Access tokens are refreshed automatically when expired.
+
+## Scopes
+
+Gemini OAuth uses the following scope by default for loopback flow:
+
+- `https://www.googleapis.com/auth/generative-language`
+
+If you are using a different Gemini backend, you may need a different scope and base URL.
+
+## OpenAI OAuth (Planned)
+
+The OAuth implementation is provider-agnostic. To add OpenAI OAuth later, the following will be needed:
+
+- OpenAI OAuth client credentials
+- OpenAI OAuth authorization endpoints and scopes
+- Wiring the provider config into the existing OAuth manager
+
+No API behavior changes are required beyond passing the bearer token into the OpenAI client.

--- a/docs/_includes/PROJECT_ROOMS.md
+++ b/docs/_includes/PROJECT_ROOMS.md
@@ -1,0 +1,445 @@
+# Project Rooms Design Document
+
+## Overview
+
+This document describes the design for a new Morpheum bot feature that allows users to create Matrix rooms corresponding to GitHub projects. The feature introduces a `!project create` command that automatically sets up a dedicated project room with GitHub Copilot integration.
+
+## User Story
+
+As a developer using Morpheum, I want to create dedicated Matrix rooms for specific GitHub projects so that I can collaborate with AI agents on project-specific tasks with automatic GitHub Copilot integration.
+
+## Command Interface
+
+### Primary Command
+```
+!project create git@github.com:user/projectname
+```
+
+**Alternative Formats Supported:**
+```
+!project create https://github.com/user/projectname
+!project create https://github.com/user/projectname.git
+!project create user/projectname
+```
+
+### Expected Behavior
+1. Parse the Git URL to extract `user/projectname` format
+2. Create a new Matrix room named `projectname`
+3. Invite the requesting user to the new room
+4. Configure the bot in that room to use GitHub Copilot for the specified repository
+5. Send confirmation messages to both the original room and the new project room
+
+## Architecture Components
+
+### 1. Git URL Parser
+
+**Purpose:** Extract repository information from various Git URL formats
+
+**Input Formats:**
+- SSH: `git@github.com:user/repo` or `git@github.com:user/repo.git`
+- HTTPS: `https://github.com/user/repo` or `https://github.com/user/repo.git`
+- Short: `user/repo`
+
+**Output:** Standardized `{ owner: string, repo: string }` object
+
+**Error Handling:**
+- Invalid URL formats
+- Missing or malformed repository names
+- Non-GitHub URLs (future: could support other Git providers)
+
+### 2. Room Creator Service
+
+**Purpose:** Handle Matrix room creation and configuration
+
+**Responsibilities:**
+- Create new Matrix room with appropriate settings
+- Set room name to project name
+- Configure room topic with repository information
+- Set appropriate room permissions and settings
+
+**Room Configuration:**
+- **Name:** Project name from repository (e.g., `morpheum`)
+- **Topic:** `GitHub Project: user/projectname - Managed by Morpheum Bot`
+- **Alias:** `#projectname-{timestamp}:homeserver.domain` (to avoid conflicts)
+- **Visibility:** Private (invite-only)
+- **History Visibility:** Shared (members can see history from when they joined)
+
+### 3. User Invitation Service
+
+**Purpose:** Manage user invitations to project rooms
+
+**Process:**
+1. Identify the requesting user from the original message
+2. Send invitation to the new project room
+3. Wait for invitation acceptance (with timeout)
+4. Handle invitation failures gracefully
+
+**Permissions:**
+- Room creator: Morpheum bot (admin level)
+- Invited user: Moderator level (can invite others, manage room)
+- Future agents: User level (can participate but not manage)
+
+### 4. Bot Configuration Manager
+
+**Purpose:** Configure bot behavior per room
+
+**Room-Specific Configuration:**
+- Store repository association in room state or local storage
+- Set GitHub Copilot as default LLM provider for the room
+- Configure repository context for Copilot sessions
+- Maintain room-to-repository mapping
+
+**Storage Options:**
+1. **Matrix Room State Events** (Recommended)
+   - Store configuration in custom state events
+   - Persistent across bot restarts
+   - Accessible to authorized room members
+
+### 5. Command Handler Integration
+
+**Integration Point:** `src/morpheum-bot/bot.ts`
+
+**New Command Handler:**
+```typescript
+private async handleProjectCommand(body: string, sendMessage: MessageSender, roomId: string, userId: string) {
+  const parts = body.split(' ');
+  const subcommand = parts[1];
+  
+  if (subcommand === 'create') {
+    await this.handleProjectCreate(parts.slice(2), sendMessage, roomId, userId);
+  } else {
+    await sendMessage('Usage: !project create <git-url>');
+  }
+}
+```
+
+## Detailed Workflow
+
+### Room Creation Flow
+
+1. **Command Parsing**
+   ```
+   User: !project create git@github.com:facebook/react
+   ```
+
+2. **URL Validation**
+   ```typescript
+   const parsed = parseGitUrl("git@github.com:facebook/react");
+   // Result: { owner: "facebook", repo: "react" }
+   ```
+
+3. **Room Creation**
+   ```typescript
+   const roomId = await matrixClient.createRoom({
+     name: "react",
+     topic: "GitHub Project: facebook/react - Managed by Morpheum Bot",
+     visibility: "private",
+     room_alias_name: `react-${timestamp}`,
+     initial_state: [
+       {
+         type: "m.room.history_visibility",
+         content: { history_visibility: "shared" }
+       },
+       {
+         type: "dev.morpheum.project_config",
+         content: {
+           repository: "facebook/react",
+           created_by: userId,
+           created_at: new Date().toISOString()
+         }
+       }
+     ]
+   });
+   ```
+
+4. **User Invitation**
+   ```typescript
+   await matrixClient.inviteUser(userId, roomId);
+   ```
+
+5. **Bot Configuration**
+   ```typescript
+   // Switch to Copilot mode for this room
+   this.roomConfigs[roomId] = {
+     llmProvider: 'copilot',
+     repository: 'facebook/react'
+   };
+   ```
+
+6. **Confirmation Messages**
+   ```
+   Original Room: "✅ Project room 'react' created! You've been invited to join."
+   New Room: "🚀 Welcome to the react project room! This room is configured for GitHub Copilot integration with facebook/react."
+   ```
+
+### Error Scenarios
+
+**Invalid Git URL:**
+```
+User: !project create invalid-url
+Bot: ❌ Invalid Git URL format. Supported formats:
+     - git@github.com:user/repo
+     - https://github.com/user/repo
+     - user/repo
+```
+
+**Room Creation Failure:**
+```
+Bot: ❌ Failed to create project room. This might be due to:
+     - Room name already exists
+     - Insufficient permissions
+     - Server connectivity issues
+     Please try again or contact an administrator.
+```
+
+**Invitation Failure:**
+```
+Bot: ✅ Project room 'react' created, but failed to invite you.
+     Please join manually: #react-{timestamp}:matrix.server.com
+```
+
+**GitHub Repository Access:**
+```
+Bot: ⚠️  Room created successfully, but unable to verify GitHub repository access.
+     Please ensure the repository exists and is accessible.
+```
+
+## Security Considerations
+
+### Authentication & Authorization
+
+**Who Can Create Project Rooms:**
+- Initially: Any authenticated Matrix user in rooms where the bot is present
+- Future: Configurable per-server or per-room permissions
+
+**Repository Access Validation:**
+- Verify GitHub repository exists and is accessible
+- Check if bot has necessary permissions for Copilot integration
+- Warn users if repository is private and bot lacks access
+
+**Room Security:**
+- All project rooms are private (invite-only)
+- Room creator gets moderator permissions
+- Bot maintains admin permissions for management
+
+### Rate Limiting
+
+**Anti-Abuse Measures:**
+- Limit room creation to 1 per user per 5 minutes
+- Maximum 100 project rooms per user total
+- Server-wide limits to prevent spam
+
+**Implementation:**
+```typescript
+interface RateLimitState {
+  userId: string;
+  lastCreation: Date;
+  totalRooms: number;
+}
+```
+
+### Data Privacy
+
+**Information Storage:**
+- Repository URLs are stored in Matrix room state (visible to room members)
+- No sensitive GitHub credentials stored in room state
+- Bot uses its own GitHub token for API access
+
+**Access Control:**
+- Room configuration only accessible to room members
+- Historical messages follow Matrix room history visibility settings
+
+## Integration Points
+
+### Matrix Bot SDK Extensions
+
+**Required Capabilities:**
+- Room creation with custom state events
+- User invitation management
+- Room-specific bot configuration
+- Event listeners for room membership changes
+
+**New Dependencies:**
+- No additional dependencies required
+- Leverage existing `matrix-bot-sdk` capabilities
+
+### GitHub Copilot Integration
+
+**Enhanced Room Context:**
+```typescript
+interface ProjectRoomConfig {
+  repository: string;
+  llmProvider: 'copilot';
+  copilotConfig: {
+    baseUrl?: string;
+    pollInterval?: number;
+  };
+}
+```
+
+**Per-Room LLM Client:**
+- Maintain separate LLM client instances per room
+- Automatic context switching based on room configuration
+- Preserve existing global bot configuration for non-project rooms
+
+### Configuration Management
+
+**Environment Variables:**
+```bash
+# Optional: Restrict project room creation
+PROJECT_ROOMS_ENABLED=true
+PROJECT_ROOMS_MAX_PER_USER=100
+PROJECT_ROOMS_RATE_LIMIT_MINUTES=5
+
+# Optional: Default room settings
+PROJECT_ROOMS_HISTORY_VISIBILITY=shared
+PROJECT_ROOMS_DEFAULT_POWER_LEVEL=50
+```
+
+**Room State Schema:**
+```json
+{
+  "type": "dev.morpheum.project_config",
+  "content": {
+    "repository": "owner/repo",
+    "created_by": "@user:server.com",
+    "created_at": "2024-01-15T10:30:00Z",
+    "llm_provider": "copilot",
+    "version": "1.0"
+  }
+}
+```
+
+## User Experience
+
+### Success Flow
+
+1. **User initiates creation:**
+   ```
+   User: !project create git@github.com:vercel/next.js
+   ```
+
+2. **Bot provides immediate feedback:**
+   ```
+   Bot: 🔨 Creating project room for next.js...
+   ```
+
+3. **Room creation confirmation:**
+   ```
+   Bot: ✅ Project room 'next.js' created successfully!
+        📧 Invitation sent - please check your Matrix client
+        🔗 Room: #next-js-1642248600:matrix.morpheum.dev
+   ```
+
+4. **User joins new room:**
+   ```
+   Bot (in new room): 🚀 Welcome to the next.js project room!
+                      
+                      This room is configured for:
+                      📂 Repository: vercel/next.js
+                      🤖 AI Provider: GitHub Copilot
+                      
+                      You can now collaborate on this project with AI assistance.
+                      Try asking: "Show me the latest issues" or "Help me implement a new feature"
+   ```
+
+### Help and Discovery
+
+**Enhanced Help Command:**
+```
+!help
+...existing commands...
+- `!project create <git-url>` - Create a new project room for a GitHub repository
+- `!project list` - List your project rooms (future enhancement)
+- `!project leave <room-name>` - Leave a project room (future enhancement)
+```
+
+**Project-Specific Help:**
+```
+!project help
+
+🏗️  **Project Room Management**
+
+**Create a project room:**
+`!project create <git-url>`
+
+**Supported URL formats:**
+- SSH: git@github.com:user/repo
+- HTTPS: https://github.com/user/repo
+- Short: user/repo
+
+**Examples:**
+- `!project create git@github.com:facebook/react`
+- `!project create https://github.com/vercel/next.js`
+- `!project create microsoft/vscode`
+
+**Features:**
+✅ Automatic GitHub Copilot integration
+✅ Private invite-only rooms
+✅ Project-specific AI context
+✅ Persistent configuration
+```
+
+## Future Enhancements
+
+### Phase 2: Room Management
+- `!project list` - List user's project rooms
+- `!project invite <user> <room>` - Invite others to project rooms
+- `!project leave <room>` - Leave a project room
+- `!project archive <room>` - Archive completed projects
+
+### Phase 3: Advanced Features
+- Multi-repository support per room
+- Integration with GitHub webhooks for real-time updates
+- Project templates and room customization
+- Cross-room project linking and dependencies
+
+## Implementation Plan
+
+### Phase 1: Core Implementation (Week 1-2)
+1. **Git URL Parser** - Parse various Git URL formats
+2. **Basic Room Creation** - Create rooms with proper configuration
+3. **User Invitation** - Invite requesting user to new room
+4. **Command Integration** - Add `!project create` to bot commands
+5. **Basic Error Handling** - Handle common failure scenarios
+
+### Phase 2: Enhanced Integration (Week 3)
+1. **Copilot Configuration** - Per-room Copilot setup
+2. **Room State Management** - Persistent configuration storage
+3. **Security Features** - Rate limiting and access controls
+4. **Improved UX** - Better error messages and help text
+
+### Phase 3: Production Readiness (Week 4)
+1. **Comprehensive Testing** - Unit and integration tests
+2. **Performance Optimization** - Efficient room management
+3. **Documentation** - User guides and API documentation
+4. **Monitoring** - Logging and metrics collection
+
+## Success Metrics
+
+**Functionality Metrics:**
+- Successful room creation rate (target: >95%)
+- User invitation success rate (target: >90%)
+- Copilot integration activation rate (target: >95%)
+
+**User Experience Metrics:**
+- Time to room creation (target: <10 seconds)
+- User adoption of project rooms (track creation frequency)
+- Error rate and user feedback quality
+
+**Technical Metrics:**
+- Room management overhead (memory/storage usage)
+- API response times for GitHub integration
+- Bot performance impact in multi-room scenarios
+
+## Conclusion
+
+The Project Rooms feature will significantly enhance Morpheum's collaborative capabilities by providing dedicated spaces for GitHub project work with automatic AI integration. The design balances user experience, security, and technical implementation while maintaining consistency with Morpheum's existing architecture.
+
+This feature leverages Morpheum's core strengths:
+- Matrix-based communication and collaboration
+- GitHub integration and workflow automation  
+- AI-powered development assistance
+- Flexible and extensible architecture
+
+The implementation will create a seamless bridge between GitHub repositories and Matrix collaboration spaces, enabling more focused and productive development workflows with integrated AI assistance.

--- a/docs/_tasks/task-999-ad-hoc-add-gemini-oauth-support.md
+++ b/docs/_tasks/task-999-ad-hoc-add-gemini-oauth-support.md
@@ -1,0 +1,12 @@
+---
+title: "Ad Hoc: Add Gemini OAuth Support"
+order: 999
+status: completed
+phase: "Morpheum v0.2: Agent Advancement"
+category: "LLM Infrastructure"
+---
+
+- [x] Add OAuth loopback (PKCE) flow and token storage for Gemini.
+- [x] Wire OAuth into the LLM client factory and bot `!llm oauth` commands.
+- [x] Document setup steps, scopes, and defaults in `OAUTH_SUPPORT.md`.
+- [x] Capture device-flow limitations and troubleshooting learnings in devlogs.

--- a/docs/_tasks/task-999-ad-hoc-fix-pages-workflow-oauth-docs.md
+++ b/docs/_tasks/task-999-ad-hoc-fix-pages-workflow-oauth-docs.md
@@ -1,0 +1,11 @@
+---
+title: "Ad Hoc: Fix Pages Workflow Trigger for OAuth Docs"
+order: 999
+status: completed
+phase: "Morpheum v0.2: Agent Advancement"
+category: "Documentation"
+---
+
+- [x] Ensure GitHub Pages rebuilds when OAuth support docs change.
+- [x] Add a documentation page that includes the root OAuth support file.
+- [x] Link OAuth support in the documentation index.

--- a/docs/_tasks/task-999-ad-hoc-unify-llm-client-factory.md
+++ b/docs/_tasks/task-999-ad-hoc-unify-llm-client-factory.md
@@ -1,0 +1,11 @@
+---
+title: "Ad Hoc: Unify LLM Client Creation and Gauntlet Defaults"
+order: 999
+status: completed
+phase: "Morpheum v0.2: Agent Advancement"
+category: "LLM Infrastructure"
+---
+
+- [x] Consolidate LLM client creation into a single async factory path.
+- [x] Update gauntlet execution to support gemini provider and default models.
+- [x] Document OAuth loopback setup and default Gemini model.

--- a/docs/documentation/index.md
+++ b/docs/documentation/index.md
@@ -36,3 +36,4 @@ Human developers are always in control. They can review, modify, and approve the
 - [**Vision Document**](vision/) - The long-term vision for Morpheum
 - [**API Reference**](api/) - Technical documentation for developers
 - [**Agent Guidelines**](agents/) - Guidelines for AI agent behavior
+- [**OAuth Support**](oauth-support/) - OAuth setup details for LLM providers

--- a/docs/documentation/oauth-support.md
+++ b/docs/documentation/oauth-support.md
@@ -4,4 +4,4 @@ title: OAuth Support
 permalink: /documentation/oauth-support/
 ---
 
-{% include_relative ../../OAUTH_SUPPORT.md %}
+{% include OAUTH_SUPPORT.md %}

--- a/docs/documentation/oauth-support.md
+++ b/docs/documentation/oauth-support.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: OAuth Support
+permalink: /documentation/oauth-support/
+---
+
+{% include_relative ../../OAUTH_SUPPORT.md %}

--- a/docs/proposals/project-rooms.md
+++ b/docs/proposals/project-rooms.md
@@ -58,7 +58,7 @@ The implementation leverages:
 
 The complete technical specification is available in the repository:
 
-{% include_relative ../../../PROJECT_ROOMS.md %}
+{% include PROJECT_ROOMS.md %}
 
 ## Community Feedback
 

--- a/src/gauntlet/gauntlet.ts
+++ b/src/gauntlet/gauntlet.ts
@@ -500,7 +500,7 @@ async function checkContainerReadiness(port: number, host: string): Promise<bool
 // Placeholder for the evaluation logic
 async function runGauntlet(
   model: string,
-  provider: 'openai' | 'ollama',
+  provider: 'openai' | 'ollama' | 'gemini',
   taskId: string,
   results: GauntletResult,
   verbose: boolean,
@@ -517,7 +517,7 @@ async function runGauntlet(
   
   try {
     // Configure the bot to use the specified provider and model
-    bot.configureForGauntlet(model, provider);
+    await bot.configureForGauntlet(model, provider);
   } catch (error) {
     console.error(`Error configuring bot: ${error instanceof Error ? error.message : String(error)}`);
     if (progressCallback) {
@@ -687,7 +687,7 @@ async function runGauntlet(
   }
   
   // Reset metrics before the task
-  bot.resetLLMMetrics();
+  await bot.resetLLMMetrics();
   
   const result = await bot.processMessage(
     task.prompt,
@@ -696,7 +696,7 @@ async function runGauntlet(
   );
 
   // 4. Capture metrics after the task
-  const taskMetrics = bot.getLLMMetrics();
+  const taskMetrics = await bot.getLLMMetrics();
 
   // 5. Capture the model's output and actions
   if (Array.isArray(result)) {
@@ -789,7 +789,7 @@ function createProgressTable(
 // Export function for use by the bot
 export async function executeGauntlet(
   model: string,
-  provider: 'openai' | 'ollama' = 'ollama',
+  provider: 'openai' | 'ollama' | 'gemini' = 'ollama',
   taskId?: string,
   verbose: boolean = false,
   progressCallback?: ProgressCallback
@@ -853,14 +853,14 @@ if (process.argv[1] === __filename) {
     .command("run")
     .description("Run the gauntlet for a specific model and task")
     .requiredOption("-m, --model <model>", "The model to evaluate")
-    .option("-p, --provider <provider>", "The LLM provider to use (openai|ollama)", "ollama")
+    .option("-p, --provider <provider>", "The LLM provider to use (openai|ollama|gemini)", "ollama")
     .option("-t, --task <task>", "The task to run (defaults to all tasks)")
     .option("-v, --verbose", "Enable verbose logging", false)
     .action(async (options) => {
       try {
         // Validate provider option
-        if (!['openai', 'ollama'].includes(options.provider)) {
-          throw new Error('--provider must be either "openai" or "ollama"');
+        if (!['openai', 'ollama', 'gemini'].includes(options.provider)) {
+          throw new Error('--provider must be either "openai", "ollama", or "gemini"');
         }
 
         const results = await executeGauntlet(

--- a/src/morpheum-bot/bot.test.ts
+++ b/src/morpheum-bot/bot.test.ts
@@ -104,7 +104,7 @@ vi.mock('./format-markdown', () => ({
         return '<p>🔍 <strong>Search Results</strong></p>\n<p>1 found</p>';
       }
     } else if (content.includes('🏆 **Gauntlet - AI Model Evaluation**')) {
-      return '<p>🏆 <strong>Gauntlet - AI Model Evaluation</strong></p>\n<p><strong>Usage:</strong></p>\n<ul>\n<li><code>!gauntlet run --model &lt;model&gt;</code> - Run gauntlet evaluation</li>\n</ul>\n<p><strong>Options:</strong></p>\n<p><code>--model &lt;model&gt;</code> - Required. The model name to evaluate</p>\n<p>⚠️ <strong>Note:</strong> Gauntlet only works with OpenAI and Ollama providers, not Copilot.</p>';
+      return '<p>🏆 <strong>Gauntlet - AI Model Evaluation</strong></p>\n<p><strong>Usage:</strong></p>\n<ul>\n<li><code>!gauntlet run [--model &lt;model&gt;] [--provider &lt;openai|ollama|gemini&gt;] [--task &lt;task&gt;] [--verbose]</code> - Run gauntlet evaluation</li>\n</ul>\n<p><strong>Options:</strong></p>\n<p><code>--model &lt;model&gt;</code> - Optional. The model name to evaluate</p>\n<p>⚠️ <strong>Note:</strong> Gauntlet works with OpenAI, Ollama, and Gemini providers, not Copilot.</p>';
     } else if (content.includes('📋 **Available Gauntlet Tasks:**')) {
       return '<p>📋 <strong>Available Gauntlet Tasks:</strong></p>\n<p><strong>Environment Management &amp; Tooling:</strong></p>\n<ul>\n<li><code>add-jq</code> (Easy) - Add jq tool for JSON parsing</li>\n</ul>\n<p><strong>Software Development &amp; Refinement:</strong></p>\n<ul>\n<li><code>hello-world-server</code> (Easy) - Create simple web server</li>\n</ul>';
     }
@@ -228,7 +228,7 @@ describe('MorpheumBot', () => {
       await bot.processMessage('!llm switch invalid', 'user', mockSendMessage);
       
       expect(mockSendMessage).toHaveBeenCalledWith(
-        expect.stringContaining('Usage: !llm switch <openai|ollama|copilot>')
+        expect.stringContaining('Usage: !llm switch <openai|ollama|gemini|copilot>')
       );
     });
 
@@ -430,11 +430,11 @@ Job's done! The program has been created successfully.
       // First parameter should be the markdown
       expect(call[0]).toContain('🏆 **Gauntlet - AI Model Evaluation**');
       expect(call[0]).toContain('**Usage:**');
-      expect(call[0]).toContain('`!gauntlet run --model <model> [--provider <openai|ollama>] [--task <task>] [--verbose]`');
+      expect(call[0]).toContain('`!gauntlet run [--model <model>] [--provider <openai|ollama|gemini>] [--task <task>] [--verbose]`');
       
       // Second parameter should be HTML
       expect(call[1]).toContain('<strong>Gauntlet - AI Model Evaluation</strong>');
-      expect(call[1]).toContain('<code>!gauntlet run --model');
+      expect(call[1]).toContain('<code>!gauntlet run [--model');
     });
 
     it('should show gauntlet list with formatted markdown', async () => {

--- a/src/morpheum-bot/bot.ts
+++ b/src/morpheum-bot/bot.ts
@@ -1,19 +1,18 @@
 import { SWEAgent } from "./sweAgent";
-import { OllamaClient } from "./ollamaClient";
-import { OpenAIClient } from "./openai";
 import { JailClient } from "./jailClient";
 import { type LLMClient, type LLMConfig, createLLMClient } from "./llmClient";
 import { TokenManager } from "./token-manager";
 import { execa } from "execa";
 import * as fs from "fs";
 import { formatMarkdown } from "./format-markdown";
-import { CopilotClient } from "./copilotClient";
+import type { CopilotClient } from "./copilotClient";
 import { getTaskFiles, filterUncompletedTasks, assembleTasksMarkdown, getTaskSummary, searchTasks } from "./task-utils";
 import * as net from "net";
 import { normalizeArgsArray } from "./dash-normalizer";
 import { ProjectRoomManager, ProjectRoomConfig, ProjectRoomCreationOptions } from "./project-room-manager";
 import { parseGitUrl } from "./git-url-parser";
 import { MatrixClient } from "matrix-bot-sdk";
+import { OAuthManager } from "./oauth/manager";
 
 type MessageSender = (message: string, html?: string) => Promise<void>;
 
@@ -53,19 +52,23 @@ function sendMarkdownMessage(markdown: string, sendMessage: MessageSender): Prom
 }
 
 export class MorpheumBot {
-  private sweAgent: SWEAgent;
+  private sweAgent?: SWEAgent;
+  private sweAgentClient?: LLMClient;
   private tokenManager?: TokenManager;
   private matrixClient?: MatrixClient;
   private projectRoomManager?: ProjectRoomManager;
   private debugMode: boolean;
 
-  private currentLLMClient: LLMClient;
-  private currentLLMProvider: 'openai' | 'ollama' | 'copilot';
+  private currentLLMClient?: LLMClient;
+  private currentLLMClientPromise?: Promise<LLMClient>;
+  private currentLLMProvider: 'openai' | 'ollama' | 'copilot' | 'gemini';
   private llmConfig: {
     openai: { apiKey?: string; model: string; baseUrl: string };
     ollama: { model: string; baseUrl: string };
+    gemini: { apiKey?: string; model: string; baseUrl: string };
     copilot: { apiKey?: string; repository?: string; baseUrl: string; pollInterval: string };
   };
+  private jailClient: JailClient;
   
   // Per-room configurations for project rooms
   private roomConfigs: Map<string, ProjectRoomConfig> = new Map();
@@ -81,6 +84,14 @@ export class MorpheumBot {
     };
     if (process.env.OPENAI_API_KEY) {
       openaiConfig.apiKey = process.env.OPENAI_API_KEY;
+    }
+
+    const geminiConfig: { apiKey?: string; model: string; baseUrl: string } = {
+      model: process.env.GEMINI_MODEL || 'gemini-3-pro-preview',
+      baseUrl: process.env.GEMINI_BASE_URL || 'https://generativelanguage.googleapis.com/v1beta',
+    };
+    if (process.env.GEMINI_API_KEY) {
+      geminiConfig.apiKey = process.env.GEMINI_API_KEY;
     }
 
     const copilotConfig: { apiKey?: string; repository?: string; baseUrl: string; pollInterval: string } = {
@@ -100,19 +111,16 @@ export class MorpheumBot {
         model: process.env.OLLAMA_MODEL || 'morpheum-local',
         baseUrl: process.env.OLLAMA_API_URL || 'http://localhost:11434',
       },
+      gemini: geminiConfig,
       copilot: copilotConfig,
     };
 
     // Default to Ollama if no OpenAI key is provided
     this.currentLLMProvider = this.llmConfig.openai.apiKey ? 'openai' : 'ollama';
     
-    // Initialize clients - this will be created lazily when needed
-    this.currentLLMClient = this.createCurrentLLMClient();
-    
     const jailHost = process.env.JAIL_HOST || "localhost";
     const jailPort = parseInt(process.env.JAIL_PORT || "10001", 10);
-    const jailClient = new JailClient(jailHost, jailPort);
-    this.sweAgent = new SWEAgent(this.currentLLMClient, jailClient);
+    this.jailClient = new JailClient(jailHost, jailPort);
   }
 
   /**
@@ -136,11 +144,48 @@ export class MorpheumBot {
     // Ollama doesn't require an API key
   }
 
+  private getGeminiOAuthManager(): OAuthManager {
+    const clientId = process.env.GOOGLE_OAUTH_CLIENT_ID;
+    const clientSecret = process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+    const scopesEnv = process.env.GOOGLE_OAUTH_SCOPES;
+    const scopes = scopesEnv
+      ? scopesEnv.split(' ').map(scope => scope.trim()).filter(Boolean)
+      : ['https://www.googleapis.com/auth/generative-language'];
+
+    if (!clientId) {
+      throw new Error('Google OAuth client ID is required. Set GOOGLE_OAUTH_CLIENT_ID environment variable.');
+    }
+
+    return new OAuthManager('gemini', {
+      clientId,
+      clientSecret,
+      scopes,
+      authEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
+      tokenEndpoint: 'https://oauth2.googleapis.com/token',
+    });
+  }
+
+  private async validateProviderAuth(provider: 'openai' | 'ollama' | 'copilot' | 'gemini'): Promise<void> {
+    if (provider === 'gemini') {
+      if (this.llmConfig.gemini.apiKey) {
+        return;
+      }
+      const manager = this.getGeminiOAuthManager();
+      const status = await manager.getStatus();
+      if (!status.hasRefreshToken && !status.hasAccessToken) {
+        throw new Error('Gemini OAuth is not configured. Run `!llm oauth gemini start` to authorize.');
+      }
+      return;
+    }
+
+    this.validateApiKey(provider as 'openai' | 'ollama' | 'copilot');
+  }
+
   /**
    * Configure the bot to use a specific model and provider for gauntlet evaluation
    */
-  public configureForGauntlet(model: string, provider: 'openai' | 'ollama') {
-    this.validateApiKey(provider);
+  public async configureForGauntlet(model: string, provider: 'openai' | 'ollama' | 'gemini') {
+    await this.validateProviderAuth(provider);
     
     if (provider === 'openai') {
       this.llmConfig.openai.model = model;
@@ -148,62 +193,71 @@ export class MorpheumBot {
     } else if (provider === 'ollama') {
       this.llmConfig.ollama.model = model;
       this.currentLLMProvider = 'ollama';
+    } else if (provider === 'gemini') {
+      this.llmConfig.gemini.model = model;
+      this.currentLLMProvider = 'gemini';
     }
     
-    // Recreate the LLM client with the new configuration
-    this.currentLLMClient = this.createCurrentLLMClient();
-    
-    // Update the SWE agent with the new LLM client but preserve the jail client
-    this.sweAgent = new SWEAgent(this.currentLLMClient, this.sweAgent.currentJailClient);
+    this.resetLLMClient();
+    await this.getSWEAgent();
   }
 
-  private createCurrentLLMClient(): LLMClient {
+  private buildLLMConfig(): LLMConfig {
     const config: LLMConfig = {
       provider: this.currentLLMProvider,
     };
 
     if (this.currentLLMProvider === 'openai') {
-      if (!this.llmConfig.openai.apiKey) {
-        throw new Error('OpenAI API key is required but not provided');
-      }
       config.apiKey = this.llmConfig.openai.apiKey;
       config.model = this.llmConfig.openai.model;
       config.baseUrl = this.llmConfig.openai.baseUrl;
     } else if (this.currentLLMProvider === 'ollama') {
       config.model = this.llmConfig.ollama.model;
       config.baseUrl = this.llmConfig.ollama.baseUrl;
+    } else if (this.currentLLMProvider === 'gemini') {
+      config.apiKey = this.llmConfig.gemini.apiKey;
+      config.model = this.llmConfig.gemini.model;
+      config.baseUrl = this.llmConfig.gemini.baseUrl;
+      if (!config.apiKey) {
+        config.oauthManager = this.getGeminiOAuthManager();
+      }
     } else if (this.currentLLMProvider === 'copilot') {
-      if (!this.llmConfig.copilot.apiKey) {
-        throw new Error('GitHub token is required but not provided');
-      }
-      if (!this.llmConfig.copilot.repository) {
-        throw new Error('Repository is required for Copilot integration');
-      }
       config.apiKey = this.llmConfig.copilot.apiKey;
       config.repository = this.llmConfig.copilot.repository;
       config.baseUrl = this.llmConfig.copilot.baseUrl;
     }
 
-    // Use the factory function, but since it's async, we need to handle this differently
-    // For now, we'll create the clients directly to maintain synchronous nature
-    if (this.currentLLMProvider === 'openai') {
-      return new OpenAIClient(
-        this.llmConfig.openai.apiKey!,
-        this.llmConfig.openai.model,
-        this.llmConfig.openai.baseUrl
-      );
-    } else if (this.currentLLMProvider === 'copilot') {
-      return new CopilotClient(
-        this.llmConfig.copilot.apiKey!,
-        this.llmConfig.copilot.repository!,
-        this.llmConfig.copilot.baseUrl
-      );
-    } else {
-      return new OllamaClient(
-        this.llmConfig.ollama.baseUrl,
-        this.llmConfig.ollama.model
-      );
+    return config;
+  }
+
+  private resetLLMClient(): void {
+    this.currentLLMClient = undefined;
+    this.currentLLMClientPromise = undefined;
+    this.sweAgent = undefined;
+    this.sweAgentClient = undefined;
+  }
+
+  private async getLLMClient(): Promise<LLMClient> {
+    if (this.currentLLMClient) {
+      return this.currentLLMClient;
     }
+
+    if (!this.currentLLMClientPromise) {
+      const config = this.buildLLMConfig();
+      this.currentLLMClientPromise = createLLMClient(config);
+    }
+
+    this.currentLLMClient = await this.currentLLMClientPromise;
+    return this.currentLLMClient;
+  }
+
+  private async getSWEAgent(): Promise<SWEAgent> {
+    const client = await this.getLLMClient();
+    if (!this.sweAgent || this.sweAgentClient !== client) {
+      this.sweAgent = new SWEAgent(client, this.jailClient);
+      this.sweAgentClient = client;
+    }
+    return this.sweAgent;
   }
 
   public async processMessage(
@@ -244,7 +298,10 @@ export class MorpheumBot {
       );
       const jailHost = process.env.JAIL_HOST || "localhost";
       const newJailClient = new JailClient(jailHost, parseInt(port, 10));
-      this.sweAgent = new SWEAgent(this.currentLLMClient, newJailClient);
+      this.jailClient = newJailClient;
+      const client = await this.getLLMClient();
+      this.sweAgent = new SWEAgent(client, newJailClient);
+      this.sweAgentClient = client;
       await sendMessage(
         `Agent reset to talk to the new container on port ${port}`,
       );
@@ -270,7 +327,10 @@ Available commands:
 - \`!llm status\` - Show current LLM provider and configuration
 - \`!llm switch openai [model] [baseUrl]\` - Switch to OpenAI (requires OPENAI_API_KEY env var)
 - \`!llm switch ollama [model] [baseUrl]\` - Switch to Ollama
+- \`!llm switch gemini [model] [baseUrl]\` - Switch to Gemini (API key or OAuth required)
 - \`!llm switch copilot <repository>\` - Switch to GitHub Copilot (requires GITHUB_TOKEN env var)
+- \`!llm oauth gemini <start|status|revoke>\` - Manage Gemini OAuth loopback flow
+- \`!llm gemini models\` - List available Gemini models and supported methods
 - \`!openai <prompt>\` - Send a direct prompt to OpenAI (requires API key)
 - \`!ollama <prompt>\` - Send a direct prompt to Ollama
 - \`!copilot status [session-id]\` - Check copilot session status
@@ -281,7 +341,7 @@ Available commands:
 - \`!project status <git-url>\` - Show repository statistics and information
 - \`!gauntlet help\` - Show gauntlet evaluation help
 - \`!gauntlet list\` - List available gauntlet tasks
-- \`!gauntlet run --model <model> [--provider <openai|ollama>] [--task <task>]\` - Run gauntlet evaluation (supports Unicode dashes like —model)
+- \`!gauntlet run [--model <model>] [--provider <openai|ollama|gemini>] [--task <task>]\` - Run gauntlet evaluation (supports Unicode dashes like —model)
 
 For regular tasks, just type your request without a command prefix.`;
       await sendMessage(message);
@@ -311,6 +371,81 @@ For regular tasks, just type your request without a command prefix.`;
   private async handleLLMCommand(body: string, sendMessage: MessageSender, roomId?: string) {
     const parts = body.split(' ');
     const subcommand = parts[1];
+
+    if (subcommand === 'gemini' && parts[2] === 'models') {
+      try {
+        const models = await this.listGeminiModels();
+        if (!models.length) {
+          await sendMessage('No Gemini models returned by the API.');
+          return;
+        }
+
+        const formatted = models
+          .map((model) => {
+            const methods = model.supportedGenerationMethods?.join(', ') || 'unknown';
+            return `- ${model.name} (methods: ${methods})`;
+          })
+          .join('\n');
+
+        await sendMessage(`Gemini models:\n${formatted}`);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        await sendMessage(`Gemini models error: ${errorMessage}`);
+      }
+      return;
+    }
+
+    if (subcommand === 'oauth') {
+      const provider = parts[2];
+      const action = parts[3];
+
+      if (provider !== 'gemini') {
+        await sendMessage('Usage: !llm oauth gemini <start|status|revoke>');
+        return;
+      }
+
+      if (!action || !['start', 'status', 'revoke'].includes(action)) {
+        await sendMessage('Usage: !llm oauth gemini <start|status|revoke>');
+        return;
+      }
+
+      try {
+        const manager = this.getGeminiOAuthManager();
+
+        if (action === 'status') {
+          const status = await manager.getStatus();
+          const expiresAt = status.expiresAt ? new Date(status.expiresAt).toISOString() : 'unknown';
+          await sendMessage(
+            `Gemini OAuth status:\n- Refresh token: ${status.hasRefreshToken ? 'configured' : 'not configured'}\n- Access token: ${status.hasAccessToken ? 'present' : 'not present'}\n- Expires at: ${expiresAt}`
+          );
+          return;
+        }
+
+        if (action === 'revoke') {
+          await manager.revokeTokens();
+          await sendMessage('Gemini OAuth tokens cleared. Run `!llm oauth gemini start` to re-authorize.');
+          return;
+        }
+
+        const { authorizationUrl, redirectUri, waitForToken } = await manager.createLoopbackAuthorization();
+        console.log(`[Gemini OAuth] Redirect URI: ${redirectUri}`);
+        await sendMessage(
+          `Gemini OAuth started.\n` +
+            `Redirect URI (for debugging, do not open): \n\`\`\`\n${redirectUri}\n\`\`\`\n` +
+            `1) Open: \n\`\`\`\n${authorizationUrl}\n\`\`\`\n` +
+            `2) Sign in and approve access\n` +
+            `Waiting for authorization...`
+        );
+
+        await waitForToken;
+
+        await sendMessage('Gemini OAuth authorization complete. You can now `!llm switch gemini`.');
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        await sendMessage(`Gemini OAuth error: ${errorMessage}`);
+      }
+      return;
+    }
 
     if (subcommand === 'status') {
       // Check for room-specific configuration first
@@ -351,22 +486,31 @@ This room has project-specific settings that override global config for tasks:
 *Note: Tasks in this room will automatically use Copilot with repository '${projectConfig.repository}'*`;
       }
 
+      let geminiOauthStatus = 'oauth=not configured';
+      try {
+        const oauthStatus = await this.getGeminiOAuthManager().getStatus();
+        geminiOauthStatus = oauthStatus.hasRefreshToken ? 'oauth=configured' : 'oauth=not configured';
+      } catch (error) {
+        geminiOauthStatus = 'oauth=not configured';
+      }
+
       // Add available providers section
       status += `\n\n**Available Providers:**
 - OpenAI: model=${this.llmConfig.openai.model}, baseUrl=${this.llmConfig.openai.baseUrl}, apiKey=${this.llmConfig.openai.apiKey ? 'configured' : 'not configured'}
 - Ollama: model=${this.llmConfig.ollama.model}, baseUrl=${this.llmConfig.ollama.baseUrl}
+- Gemini: model=${this.llmConfig.gemini.model}, baseUrl=${this.llmConfig.gemini.baseUrl}, apiKey=${this.llmConfig.gemini.apiKey ? 'configured' : 'not configured'}, ${geminiOauthStatus}
 - Copilot: repository=${this.llmConfig.copilot.repository || 'not configured'}, baseUrl=${this.llmConfig.copilot.baseUrl}, apiKey=${this.llmConfig.copilot.apiKey ? 'configured' : 'not configured'}`;
 
       await sendMarkdownMessage(status, sendMessage);
     } else if (subcommand === 'switch') {
-      const provider = parts[2] as 'openai' | 'ollama' | 'copilot';
-      if (!provider || !['openai', 'ollama', 'copilot'].includes(provider)) {
-        await sendMessage('Usage: !llm switch <openai|ollama|copilot> [model] [baseUrl] or !llm switch copilot <repository>');
+      const provider = parts[2] as 'openai' | 'ollama' | 'copilot' | 'gemini';
+      if (!provider || !['openai', 'ollama', 'copilot', 'gemini'].includes(provider)) {
+        await sendMessage('Usage: !llm switch <openai|ollama|gemini|copilot> [model] [baseUrl] or !llm switch copilot <repository>');
         return;
       }
 
       try {
-        this.validateApiKey(provider);
+        await this.validateProviderAuth(provider);
 
         if (provider === 'copilot') {
           // For copilot, the third parameter is the repository
@@ -387,10 +531,8 @@ This room has project-specific settings that override global config for tasks:
         }
 
         this.currentLLMProvider = provider;
-        this.currentLLMClient = this.createCurrentLLMClient();
-        
-        // Update the SWE agent with new LLM client but preserve the current jail client
-        this.sweAgent = new SWEAgent(this.currentLLMClient, this.sweAgent.currentJailClient);
+        this.resetLLMClient();
+        await this.getSWEAgent();
 
         if (provider === 'copilot') {
           await sendMessage(`Switched to ${provider} (repository: ${this.llmConfig.copilot.repository}, baseUrl: ${this.llmConfig.copilot.baseUrl})`);
@@ -402,8 +544,38 @@ This room has project-specific settings that override global config for tasks:
         await sendMessage(`Error switching LLM provider: ${errorMessage}`);
       }
     } else {
-      await sendMessage('Usage: !llm <status|switch>');
+      await sendMessage('Usage: !llm <status|switch|oauth> or !llm gemini models');
     }
+  }
+
+  private async listGeminiModels(): Promise<{ name: string; supportedGenerationMethods?: string[] }[]> {
+    const headers: Record<string, string> = {};
+
+    if (this.llmConfig.gemini.apiKey) {
+      headers['x-goog-api-key'] = this.llmConfig.gemini.apiKey;
+    } else {
+      const oauthManager = this.getGeminiOAuthManager();
+      const accessToken = await oauthManager.getAccessToken();
+      headers['Authorization'] = `Bearer ${accessToken}`;
+    }
+
+    const response = await fetch(`${this.llmConfig.gemini.baseUrl}/models`, {
+      method: 'GET',
+      headers,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Gemini API request failed with status ${response.status}: ${errorText}`);
+    }
+
+    const data = await response.json();
+    const models = Array.isArray(data.models) ? data.models : [];
+
+    return models.map((model) => ({
+      name: model.name,
+      supportedGenerationMethods: model.supportedGenerationMethods,
+    }));
   }
 
   private async handleDirectOpenAICommand(body: string, sendMessage: MessageSender) {
@@ -421,11 +593,12 @@ This room has project-specific settings that override global config for tasks:
     }
 
     try {
-      const client = new OpenAIClient(
-        this.llmConfig.openai.apiKey,
-        this.llmConfig.openai.model,
-        this.llmConfig.openai.baseUrl
-      );
+      const client = await createLLMClient({
+        provider: 'openai',
+        apiKey: this.llmConfig.openai.apiKey,
+        model: this.llmConfig.openai.model,
+        baseUrl: this.llmConfig.openai.baseUrl,
+      });
       
       await sendMessage(`🤖 OpenAI is thinking...`);
       
@@ -449,10 +622,11 @@ This room has project-specific settings that override global config for tasks:
     }
 
     try {
-      const client = new OllamaClient(
-        this.llmConfig.ollama.baseUrl,
-        this.llmConfig.ollama.model
-      );
+      const client = await createLLMClient({
+        provider: 'ollama',
+        model: this.llmConfig.ollama.model,
+        baseUrl: this.llmConfig.ollama.baseUrl,
+      });
       
       await sendMessage(`🤖 Ollama is thinking...`);
       
@@ -484,7 +658,7 @@ This room has project-specific settings that override global config for tasks:
     }
 
     try {
-      const copilotClient = this.currentLLMClient as CopilotClient;
+      const copilotClient = (await this.getLLMClient()) as CopilotClient;
 
       switch (subcommand) {
         case 'status':
@@ -623,13 +797,13 @@ This room has project-specific settings that override global config for tasks:
       const helpMessage = `🏆 **Gauntlet - AI Model Evaluation**
 
 **Usage:**
-- \`!gauntlet run --model <model> [--provider <openai|ollama>] [--task <task>] [--verbose]\` - Run gauntlet evaluation
+- \`!gauntlet run [--model <model>] [--provider <openai|ollama|gemini>] [--task <task>] [--verbose]\` - Run gauntlet evaluation
 - \`!gauntlet list\` - List available tasks
 - \`!gauntlet help\` - Show this help message
 
 **Options:**
-- \`--model <model>\` - Required. The model name to evaluate
-- \`--provider <openai|ollama>\` - Optional. LLM provider to use (defaults to ollama)
+- \`--model <model>\` - Optional. The model name to evaluate (defaults to provider's configured model)
+- \`--provider <openai|ollama|gemini>\` - Optional. LLM provider to use (defaults to current provider)
 - \`--task <task>\` - Optional. Specific task ID to run (runs all tasks if not specified)
 - \`--verbose\` - Optional. Enable verbose output
 
@@ -650,9 +824,10 @@ Examples: \`—model\`, \`–verbose\`, \`—provider\` work the same as \`--mod
 **Examples:**
 - \`!gauntlet run --model gpt-4 --provider openai\` - Run all tasks with GPT-4 via OpenAI
 - \`!gauntlet run --model llama2 --provider ollama --task add-jq\` - Run specific task with Ollama
-- \`!gauntlet run --model llama3 --verbose\` - Run with verbose output (defaults to ollama)
+- \`!gauntlet run --provider gemini\` - Run with Gemini using the default configured model
+- \`!gauntlet run --model gemini-3-pro-preview --provider gemini\` - Run with a specific Gemini model
 
-⚠️ **Note:** Gauntlet only works with OpenAI and Ollama providers, not Copilot.`;
+⚠️ **Note:** Gauntlet works with OpenAI, Ollama, and Gemini providers, not Copilot.`;
       await sendMarkdownMessage(helpMessage, sendMessage);
       return;
     }
@@ -672,7 +847,7 @@ Examples: \`—model\`, \`–verbose\`, \`—provider\` work the same as \`--mod
 - \`create-hugo-site\` (Medium) - Set up Hugo static site
 - \`refine-existing-codebase\` (Hard) - Improve existing code
 
-Use \`!gauntlet run --model <model> --task <task-id>\` to run a specific task.`;
+Use \`!gauntlet run [--model <model>] --task <task-id>\` to run a specific task.`;
       await sendMarkdownMessage(tasksMessage, sendMessage);
       return;
     }
@@ -690,7 +865,10 @@ Use \`!gauntlet run --model <model> --task <task-id>\` to run a specific task.`;
     const normalizedArgs = normalizeArgsArray(args);
     
     let model: string | null = null;
-    let provider: 'openai' | 'ollama' = 'ollama';
+    const defaultProvider = ['openai', 'ollama', 'gemini'].includes(this.currentLLMProvider)
+      ? this.currentLLMProvider
+      : 'ollama';
+    let provider: 'openai' | 'ollama' | 'gemini' = defaultProvider as 'openai' | 'ollama' | 'gemini';
     let task: string | null = null;
     let verbose = false;
 
@@ -700,10 +878,10 @@ Use \`!gauntlet run --model <model> --task <task-id>\` to run a specific task.`;
         i++; // Skip next argument
       } else if (normalizedArgs[i] === '--provider' || normalizedArgs[i] === '-p') {
         const providerArg = normalizedArgs[i + 1];
-        if (providerArg && ['openai', 'ollama'].includes(providerArg)) {
-          provider = providerArg as 'openai' | 'ollama';
+        if (providerArg && ['openai', 'ollama', 'gemini'].includes(providerArg)) {
+          provider = providerArg as 'openai' | 'ollama' | 'gemini';
         } else {
-          await sendMessage('Error: --provider must be either "openai" or "ollama"');
+          await sendMessage('Error: --provider must be either "openai", "ollama", or "gemini"');
           return;
         }
         i++; // Skip next argument
@@ -716,13 +894,21 @@ Use \`!gauntlet run --model <model> --task <task-id>\` to run a specific task.`;
     }
 
     if (!model) {
-      await sendMessage('Error: --model is required. Usage: !gauntlet run --model <model> [--provider <openai|ollama>] [--task <task>] [--verbose]');
-      return;
+      if (provider === 'openai') {
+        model = this.llmConfig.openai.model;
+      } else if (provider === 'gemini') {
+        model = this.llmConfig.gemini.model;
+      } else {
+        model = this.llmConfig.ollama.model;
+      }
     }
 
     // Validate provider requirements
-    if (provider === 'openai' && !this.llmConfig.openai.apiKey) {
-      await sendMessage('Error: OpenAI provider requires OPENAI_API_KEY environment variable to be set.');
+    try {
+      await this.validateProviderAuth(provider);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      await sendMessage(`Error: ${errorMessage}`);
       return;
     }
 
@@ -1037,7 +1223,7 @@ ${contributorsList}${contributorsNote}
    * Returns the original configuration state to restore later
    */
   private async applyRoomSpecificConfig(roomId?: string): Promise<{
-    provider: 'openai' | 'ollama' | 'copilot';
+    provider: 'openai' | 'ollama' | 'copilot' | 'gemini';
     repository?: string;
     client: LLMClient;
   } | null> {
@@ -1072,7 +1258,7 @@ ${contributorsList}${contributorsNote}
     const originalConfig = {
       provider: this.currentLLMProvider,
       repository: this.llmConfig.copilot.repository,
-      client: this.currentLLMClient
+      client: await this.getLLMClient()
     };
 
     // Apply project room configuration
@@ -1083,15 +1269,8 @@ ${contributorsList}${contributorsNote}
       this.llmConfig.copilot.repository = projectConfig.repository;
       this.currentLLMProvider = 'copilot';
       
-      // Create new LLM client with project repository
-      this.currentLLMClient = new CopilotClient(
-        this.llmConfig.copilot.apiKey!,
-        projectConfig.repository,
-        this.llmConfig.copilot.baseUrl
-      );
-      
-      // Update the SWE agent with the new LLM client
-      this.sweAgent = new SWEAgent(this.currentLLMClient, this.sweAgent.currentJailClient);
+      this.resetLLMClient();
+      await this.getSWEAgent();
       
       return originalConfig;
     } catch (error) {
@@ -1105,7 +1284,7 @@ ${contributorsList}${contributorsNote}
    * Restore the original configuration after processing a room-specific task
    */
   private async restoreOriginalConfig(originalConfig: {
-    provider: 'openai' | 'ollama' | 'copilot';
+    provider: 'openai' | 'ollama' | 'copilot' | 'gemini';
     repository?: string;
     client: LLMClient;
   }): Promise<void> {
@@ -1114,9 +1293,9 @@ ${contributorsList}${contributorsNote}
       this.currentLLMProvider = originalConfig.provider;
       this.llmConfig.copilot.repository = originalConfig.repository;
       this.currentLLMClient = originalConfig.client;
-      
-      // Update the SWE agent with the original LLM client
-      this.sweAgent = new SWEAgent(this.currentLLMClient, this.sweAgent.currentJailClient);
+      this.currentLLMClientPromise = Promise.resolve(originalConfig.client);
+      this.sweAgent = new SWEAgent(originalConfig.client, this.jailClient);
+      this.sweAgentClient = originalConfig.client;
     } catch (error) {
       console.error('[ProjectRoom] Failed to restore original configuration:', error);
     }
@@ -1163,7 +1342,8 @@ ${contributorsList}${contributorsNote}
       const prompt = conversationHistory.map((msg) => `${msg.role}: ${msg.content}`).join('\n\n');
       
       // Call LLM without streaming chunks to user - we'll show structured progress instead
-      const modelResponse = await this.currentLLMClient.sendStreaming(prompt, () => {
+      const client = await this.getLLMClient();
+      const modelResponse = await client.sendStreaming(prompt, () => {
         // Don't send chunks to user to avoid verbose output
       });
       
@@ -1207,7 +1387,8 @@ ${nextStep}`;
         const executingCommandMarkdown = `⚡ **Executing command:** ${formattedCommand}`;
         await sendMarkdownMessage(executingCommandMarkdown, sendMessage);
         
-        const commandOutput = await this.sweAgent.currentJailClient.execute(commands[0]!);
+        const sweAgent = await this.getSWEAgent();
+        const commandOutput = await sweAgent.currentJailClient.execute(commands[0]!);
         conversationHistory.push({ role: 'tool', content: commandOutput });
         
         // Smart output display: show small outputs directly, large outputs with prefix + spoiler
@@ -1291,7 +1472,8 @@ ${spoilerContent}
     // For Copilot, we send just the user's task without system prompts
     // since Copilot already understands repository context
     // The CopilotClient handles all status updates including issue creation
-    const response = await this.currentLLMClient.sendStreaming(task, async (chunk) => {
+    const client = await this.getLLMClient();
+    const response = await client.sendStreaming(task, async (chunk) => {
       // Handle special dual messages for iframe content
       if (chunk.startsWith('__DUAL_MESSAGE__')) {
         try {
@@ -1388,14 +1570,16 @@ ${status.hasCredentials && status.hasAccessToken ?
   /**
    * Get accumulated LLM metrics from the current client
    */
-  getLLMMetrics() {
-    return this.currentLLMClient.getMetrics?.() || null;
+  async getLLMMetrics() {
+    const client = await this.getLLMClient();
+    return client.getMetrics?.() || null;
   }
 
   /**
    * Reset LLM metrics for the current client
    */
-  resetLLMMetrics() {
-    this.currentLLMClient.resetMetrics?.();
+  async resetLLMMetrics() {
+    const client = await this.getLLMClient();
+    client.resetMetrics?.();
   }
 }

--- a/src/morpheum-bot/gauntlet.integration.test.ts
+++ b/src/morpheum-bot/gauntlet.integration.test.ts
@@ -34,6 +34,7 @@ describe('Gauntlet Integration', () => {
 
   beforeEach(() => {
     mockSendMessage = vi.fn();
+    process.env.OLLAMA_MODEL = 'morpheum-local';
     bot = new MorpheumBot();
     vi.clearAllMocks();
   });
@@ -104,13 +105,15 @@ describe('Gauntlet Integration', () => {
     delete process.env.OPENAI_API_KEY;
   });
 
-  it('should require model parameter for gauntlet run', async () => {
-    await bot.processMessage('!gauntlet run --task test-task', 'test-user', mockSendMessage);
+  it('should default to configured model when model is not provided', async () => {
+    const mockExecuteGauntlet = vi.mocked(executeGauntlet);
+    mockExecuteGauntlet.mockResolvedValue({
+      'test-task': { success: true }
+    });
 
-    // Should show error message for missing model
-    expect(mockSendMessage).toHaveBeenCalledWith(
-      expect.stringContaining('Error: --model is required')
-    );
+    await bot.processMessage('!gauntlet run --provider ollama --task test-task', 'test-user', mockSendMessage);
+
+    expect(mockExecuteGauntlet).toHaveBeenCalledWith('morpheum-local', 'ollama', 'test-task', false, expect.any(Function));
   });
 
   it('should validate provider parameter for gauntlet run', async () => {
@@ -118,7 +121,7 @@ describe('Gauntlet Integration', () => {
 
     // Should show error message for invalid provider
     expect(mockSendMessage).toHaveBeenCalledWith(
-      expect.stringContaining('Error: --provider must be either "openai" or "ollama"')
+      expect.stringContaining('Error: --provider must be either "openai", "ollama", or "gemini"')
     );
   });
 
@@ -131,7 +134,7 @@ describe('Gauntlet Integration', () => {
 
     // Should show error about missing API key
     expect(mockSendMessage).toHaveBeenCalledWith(
-      expect.stringContaining('Error: OpenAI provider requires OPENAI_API_KEY environment variable to be set.')
+      expect.stringContaining('Error: OpenAI API key is not configured')
     );
   });
 
@@ -176,7 +179,7 @@ describe('Gauntlet Integration', () => {
 
     // Should show error about invalid provider
     expect(mockSendMessage).toHaveBeenCalledWith(
-      expect.stringContaining('Error: --provider must be either "openai" or "ollama"')
+      expect.stringContaining('Error: --provider must be either "openai", "ollama", or "gemini"')
     );
   });
 

--- a/src/morpheum-bot/geminiClient.ts
+++ b/src/morpheum-bot/geminiClient.ts
@@ -1,0 +1,86 @@
+import { type LLMClient } from './llmClient';
+import { type LLMMetrics, MetricsTracker, estimateTokens } from './metrics';
+import { type OAuthManager } from './oauth/manager';
+
+interface GeminiAuthConfig {
+  apiKey?: string;
+  oauthManager?: OAuthManager;
+}
+
+export class GeminiClient implements LLMClient {
+  private metricsTracker = new MetricsTracker();
+
+  constructor(
+    private readonly auth: GeminiAuthConfig,
+    private readonly model: string,
+    private readonly baseUrl: string = 'https://generativelanguage.googleapis.com/v1beta'
+  ) {}
+
+  getMetrics(): LLMMetrics | null {
+    return this.metricsTracker.getMetrics();
+  }
+
+  resetMetrics(): void {
+    this.metricsTracker.reset();
+  }
+
+  async send(prompt: string): Promise<string> {
+    const response = await this.sendRequest(prompt, false);
+    return response;
+  }
+
+  async sendStreaming(prompt: string, onChunk: (chunk: string) => void): Promise<string> {
+    const content = await this.sendRequest(prompt, true);
+    onChunk(content);
+    return content;
+  }
+
+  private async sendRequest(prompt: string, isStreaming: boolean): Promise<string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    if (this.auth.apiKey) {
+      headers['x-goog-api-key'] = this.auth.apiKey;
+    } else if (this.auth.oauthManager) {
+      const accessToken = await this.auth.oauthManager.getAccessToken();
+      headers['Authorization'] = `Bearer ${accessToken}`;
+    } else {
+      throw new Error('Gemini authentication is not configured');
+    }
+
+    const modelPath = this.model.startsWith('models/') ? this.model : `models/${this.model}`;
+    const endpoint = `${this.baseUrl}/${modelPath}:generateContent`;
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: prompt }],
+          },
+        ],
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      throw new Error(`Gemini API request failed with status ${response.status}: ${errorData}`);
+    }
+
+    const data = await response.json();
+    const content = data.candidates?.[0]?.content?.parts?.map((part: any) => part.text).join('') || '';
+
+    const inputTokens = estimateTokens(prompt);
+    const outputTokens = estimateTokens(content);
+    this.metricsTracker.addRequest(inputTokens, outputTokens);
+
+    if (isStreaming) {
+      return content;
+    }
+
+    return content;
+  }
+}

--- a/src/morpheum-bot/llmClient.test.ts
+++ b/src/morpheum-bot/llmClient.test.ts
@@ -3,6 +3,7 @@ import { createLLMClient, LLMConfig } from './llmClient';
 import { OpenAIClient } from './openai';
 import { OllamaClient } from './ollamaClient';
 import { CopilotClient } from './copilotClient';
+import { GeminiClient } from './geminiClient';
 
 describe('LLM Client Factory', () => {
   it('should create OpenAI client with valid config', async () => {
@@ -40,6 +41,17 @@ describe('LLM Client Factory', () => {
     expect(client).toBeInstanceOf(CopilotClient);
   });
 
+  it('should create Gemini client with valid config', async () => {
+    const config: LLMConfig = {
+      provider: 'gemini',
+      apiKey: 'test-gemini-key',
+      model: 'gemini-1.5-pro',
+    };
+
+    const client = await createLLMClient(config);
+    expect(client).toBeInstanceOf(GeminiClient);
+  });
+
   it('should throw error for OpenAI without API key', async () => {
     const config: LLMConfig = {
       provider: 'openai',
@@ -65,6 +77,15 @@ describe('LLM Client Factory', () => {
     };
 
     await expect(createLLMClient(config)).rejects.toThrow('Repository name is required for Copilot integration');
+  });
+
+  it('should throw error for Gemini without API key', async () => {
+    const config: LLMConfig = {
+      provider: 'gemini',
+      model: 'gemini-1.5-pro',
+    };
+
+    await expect(createLLMClient(config)).rejects.toThrow('Gemini API key or OAuth manager is required');
   });
 
   it('should throw error for unsupported provider', async () => {

--- a/src/morpheum-bot/llmClient.ts
+++ b/src/morpheum-bot/llmClient.ts
@@ -1,4 +1,5 @@
 import { type LLMMetrics, MetricsTracker } from './metrics';
+import { OAuthManager } from './oauth/manager';
 
 /**
  * Common interface for LLM clients (OpenAI, Ollama, etc.)
@@ -35,11 +36,12 @@ export interface LLMClient {
  * Configuration for different LLM providers
  */
 export interface LLMConfig {
-  provider: 'openai' | 'ollama' | 'copilot';
+  provider: 'openai' | 'ollama' | 'copilot' | 'gemini';
   apiKey?: string;
   model?: string;
   baseUrl?: string;
   repository?: string; // New field for GitHub repo (required for copilot)
+  oauthManager?: OAuthManager;
 }
 
 /**
@@ -77,6 +79,17 @@ export async function createLLMClient(config: LLMConfig): Promise<LLMClient> {
         config.apiKey,
         config.repository,
         config.baseUrl || 'https://api.github.com'
+      );
+
+    case 'gemini':
+      const { GeminiClient } = await import('./geminiClient');
+      if (!config.apiKey && !config.oauthManager) {
+        throw new Error('Gemini API key or OAuth manager is required');
+      }
+      return new GeminiClient(
+        config.apiKey ? { apiKey: config.apiKey } : { oauthManager: config.oauthManager },
+        config.model || 'gemini-3-pro-preview',
+        config.baseUrl || 'https://generativelanguage.googleapis.com/v1beta'
       );
     
     default:

--- a/src/morpheum-bot/oauth/manager.ts
+++ b/src/morpheum-bot/oauth/manager.ts
@@ -1,0 +1,203 @@
+import http from 'http';
+import { randomBytes, createHash } from 'crypto';
+import { getProviderTokens, setProviderTokens, type OAuthProvider, type OAuthTokenRecord } from './store';
+
+export interface OAuthClientConfig {
+  clientId: string;
+  clientSecret?: string;
+  scopes: string[];
+  authEndpoint: string;
+  tokenEndpoint: string;
+}
+
+export class OAuthManager {
+  constructor(private readonly provider: OAuthProvider, private readonly config: OAuthClientConfig) {}
+
+  async createLoopbackAuthorization(): Promise<{ authorizationUrl: string; redirectUri: string; waitForToken: Promise<OAuthTokenRecord> }> {
+    const state = this.randomString(16);
+    const codeVerifier = this.randomString(64);
+    const codeChallenge = this.base64UrlEncode(createHash('sha256').update(codeVerifier).digest());
+
+    const server = http.createServer();
+    let redirectUri = '';
+
+    const waitForToken = new Promise<OAuthTokenRecord>((resolve, reject) => {
+      server.on('request', async (req, res) => {
+        try {
+        const url = new URL(req.url || '/', 'http://127.0.0.1');
+          if (url.pathname !== '/oauth2callback') {
+            res.writeHead(404, { 'Content-Type': 'text/plain' });
+            res.end('Not found');
+            return;
+          }
+
+          const code = url.searchParams.get('code');
+          const returnedState = url.searchParams.get('state');
+          if (!code) {
+            res.writeHead(400, { 'Content-Type': 'text/plain' });
+            res.end('Missing authorization code');
+            return;
+          }
+          if (!returnedState || returnedState !== state) {
+            res.writeHead(400, { 'Content-Type': 'text/plain' });
+            res.end('State mismatch');
+            return;
+          }
+
+          res.writeHead(200, { 'Content-Type': 'text/plain' });
+          res.end('Authorization complete. You can return to the chat.');
+
+          server.close();
+
+          const record = await this.exchangeCodeForToken(code, codeVerifier, redirectUri);
+          await setProviderTokens(this.provider, record);
+          resolve(record);
+        } catch (error) {
+          server.close();
+          reject(error);
+        }
+      });
+    });
+
+    redirectUri = await new Promise<string>((resolve, reject) => {
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address();
+        if (typeof address === 'object' && address?.port) {
+          resolve(`http://127.0.0.1:${address.port}/oauth2callback`);
+        } else {
+          reject(new Error('Failed to determine loopback port'));
+        }
+      });
+      server.on('error', reject);
+    });
+
+    const authUrl = new URL(this.config.authEndpoint);
+    authUrl.searchParams.set('client_id', this.config.clientId);
+    authUrl.searchParams.set('redirect_uri', redirectUri);
+    authUrl.searchParams.set('response_type', 'code');
+    authUrl.searchParams.set('scope', this.config.scopes.join(' '));
+    authUrl.searchParams.set('access_type', 'offline');
+    authUrl.searchParams.set('prompt', 'consent');
+    authUrl.searchParams.set('state', state);
+    authUrl.searchParams.set('code_challenge', codeChallenge);
+    authUrl.searchParams.set('code_challenge_method', 'S256');
+
+    return { authorizationUrl: authUrl.toString(), redirectUri, waitForToken };
+  }
+
+  async getAccessToken(): Promise<string> {
+    const record = await getProviderTokens(this.provider);
+    if (!record) {
+      throw new Error('OAuth tokens not configured. Run the OAuth flow first.');
+    }
+
+    const now = Date.now();
+    if (record.accessToken && record.expiresAt && record.expiresAt - now > 60000) {
+      return record.accessToken;
+    }
+
+    if (!record.refreshToken) {
+      throw new Error('OAuth refresh token is missing. Re-run the OAuth flow.');
+    }
+
+    const refreshed = await this.refreshToken(record.refreshToken);
+    await setProviderTokens(this.provider, refreshed);
+    if (!refreshed.accessToken) {
+      throw new Error('OAuth refresh did not return an access token');
+    }
+    return refreshed.accessToken;
+  }
+
+  async getStatus(): Promise<{ hasRefreshToken: boolean; hasAccessToken: boolean; expiresAt?: number }> {
+    const record = await getProviderTokens(this.provider);
+    return {
+      hasRefreshToken: Boolean(record?.refreshToken),
+      hasAccessToken: Boolean(record?.accessToken),
+      expiresAt: record?.expiresAt,
+    };
+  }
+
+  async revokeTokens(): Promise<void> {
+    await setProviderTokens(this.provider, undefined);
+  }
+
+  private async exchangeCodeForToken(code: string, codeVerifier: string, redirectUri: string): Promise<OAuthTokenRecord> {
+    const body = new URLSearchParams({
+      client_id: this.config.clientId,
+      code,
+      code_verifier: codeVerifier,
+      redirect_uri: redirectUri,
+      grant_type: 'authorization_code',
+    });
+
+    if (this.config.clientSecret) {
+      body.set('client_secret', this.config.clientSecret);
+    }
+
+    const response = await fetch(this.config.tokenEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`OAuth token exchange failed: ${response.status} ${errorText}`);
+    }
+
+    const data = await response.json();
+    return this.normalizeTokenResponse(data);
+  }
+
+  private async refreshToken(refreshToken: string): Promise<OAuthTokenRecord> {
+    const body = new URLSearchParams({
+      client_id: this.config.clientId,
+      refresh_token: refreshToken,
+      grant_type: 'refresh_token',
+    });
+
+    if (this.config.clientSecret) {
+      body.set('client_secret', this.config.clientSecret);
+    }
+
+    const response = await fetch(this.config.tokenEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`OAuth refresh failed: ${response.status} ${errorText}`);
+    }
+
+    const data = await response.json();
+    const normalized = this.normalizeTokenResponse(data);
+    normalized.refreshToken = normalized.refreshToken || refreshToken;
+    return normalized;
+  }
+
+  private normalizeTokenResponse(data: any): OAuthTokenRecord {
+    const expiresIn = typeof data.expires_in === 'number' ? data.expires_in : undefined;
+    const expiresAt = expiresIn ? Date.now() + expiresIn * 1000 : undefined;
+
+    return {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token,
+      expiresAt,
+      scopes: typeof data.scope === 'string' ? data.scope.split(' ') : undefined,
+    };
+  }
+
+  private randomString(bytes: number): string {
+    return this.base64UrlEncode(randomBytes(bytes));
+  }
+
+  private base64UrlEncode(buffer: Buffer): string {
+    return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  }
+}

--- a/src/morpheum-bot/oauth/store.ts
+++ b/src/morpheum-bot/oauth/store.ts
@@ -1,0 +1,71 @@
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+export type OAuthProvider = 'gemini' | 'openai';
+
+export interface OAuthTokenRecord {
+  accessToken?: string;
+  refreshToken?: string;
+  expiresAt?: number;
+  scopes?: string[];
+}
+
+export interface OAuthStoreData {
+  version: number;
+  providers: Record<OAuthProvider, OAuthTokenRecord | undefined>;
+}
+
+const DEFAULT_STORE: OAuthStoreData = {
+  version: 1,
+  providers: {},
+};
+
+export function getOAuthStorePath(): string {
+  return path.join(os.homedir(), '.config', 'morpheum', 'oauth.json');
+}
+
+async function ensureStoreDir(): Promise<void> {
+  const storePath = getOAuthStorePath();
+  const dir = path.dirname(storePath);
+  await fs.mkdir(dir, { recursive: true });
+}
+
+export async function readOAuthStore(): Promise<OAuthStoreData> {
+  const storePath = getOAuthStorePath();
+  try {
+    const raw = await fs.readFile(storePath, 'utf8');
+    const parsed = JSON.parse(raw) as OAuthStoreData;
+    if (!parsed.version || !parsed.providers) {
+      return { ...DEFAULT_STORE };
+    }
+    return parsed;
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      return { ...DEFAULT_STORE };
+    }
+    throw error;
+  }
+}
+
+export async function writeOAuthStore(data: OAuthStoreData): Promise<void> {
+  await ensureStoreDir();
+  const storePath = getOAuthStorePath();
+  const serialized = JSON.stringify(data, null, 2);
+  await fs.writeFile(storePath, serialized, 'utf8');
+}
+
+export async function getProviderTokens(provider: OAuthProvider): Promise<OAuthTokenRecord | undefined> {
+  const store = await readOAuthStore();
+  return store.providers[provider];
+}
+
+export async function setProviderTokens(provider: OAuthProvider, record?: OAuthTokenRecord): Promise<void> {
+  const store = await readOAuthStore();
+  if (record) {
+    store.providers[provider] = record;
+  } else {
+    delete store.providers[provider];
+  }
+  await writeOAuthStore(store);
+}


### PR DESCRIPTION
## Summary\n- consolidate LLM client creation through the async factory with lazy initialization\n- support Gemini OAuth configuration in the shared factory path\n- allow gauntlet defaults to use provider-configured models and add Gemini provider support\n- document OAuth loopback setup and default Gemini model\n\n## Testing\n- not run (pre-commit blocked unrelated test harness earlier)